### PR TITLE
Refactor React setup scripts for easier use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Scripts
+
+This repository contains helper scripts for bootstrapping React projects.
+
+## Setup React App
+
+Run the `setup-react-app.js` script to create a new React app inside `all_projects/webApps` and optionally enable features.
+
+```bash
+node setupReactAppScripts/scripts/setup-react-app.js <project-name>
+```
+
+You will be prompted to enable Tailwind with Prettier, Firebase, and GitHub integration.
+
+After the base app is created you can run the additional `post-setup-react.js` script to install extra packages and set up serverless functions:
+
+```bash
+node setupReactAppScripts/scripts/post-setup-react.js <path-to-project>
+```
+
+The scripts are mostly plug and play and require only Node.js and npm to be installed.

--- a/setupReactAppScripts/scripts/features/firebase.js
+++ b/setupReactAppScripts/scripts/features/firebase.js
@@ -1,17 +1,20 @@
 // features/firebase.js
 const { executeCommand } = require("../utils");
 
-// Get the project directory from command-line arguments
-const appDirectory = process.argv[2];
-if (!appDirectory) {
-  console.error("Please provide the path to your React app directory.");
-  process.exit(1);
-}
-
-(async function addFirebaseConfig() {
+async function addFirebaseConfig(appDirectory) {
+  if (!appDirectory) {
+    console.error("Please provide the path to your React app directory.");
+    process.exit(1);
+  }
   console.log("\n--- Adding Firebase ---");
-  
+
   executeCommand("npm install firebase", { cwd: appDirectory });
   executeCommand("npm install -g firebase-tools", { cwd: appDirectory });
+}
 
-})();
+module.exports = addFirebaseConfig;
+
+if (require.main === module) {
+  const appDirectory = process.argv[2];
+  addFirebaseConfig(appDirectory);
+}

--- a/setupReactAppScripts/scripts/features/github.js
+++ b/setupReactAppScripts/scripts/features/github.js
@@ -2,14 +2,11 @@
 const path = require("path");
 const { executeCommand, askQuestion } = require("../utils");
 
-// Get the project directory from command-line arguments
-const appDirectory = process.argv[2];
-if (!appDirectory) {
-  console.error("Please provide the path to your React app directory.");
-  process.exit(1);
-}
-
-(async function setupGitHub() {
+async function setupGitHub(appDirectory) {
+  if (!appDirectory) {
+    console.error("Please provide the path to your React app directory.");
+    process.exit(1);
+  }
   console.log("\n--- Setting Up GitHub Integration ---");
 
   const githubRepoUrl = await askQuestion(
@@ -41,4 +38,11 @@ if (!appDirectory) {
   } else {
     console.log("ℹ️  GitHub repository URL not provided. Skipping GitHub integration.");
   }
-})();
+}
+
+module.exports = setupGitHub;
+
+if (require.main === module) {
+  const appDirectory = process.argv[2];
+  setupGitHub(appDirectory);
+}

--- a/setupReactAppScripts/scripts/features/stripe.js
+++ b/setupReactAppScripts/scripts/features/stripe.js
@@ -3,14 +3,11 @@ const fs = require("fs");
 const path = require("path");
 const { executeCommand } = require("../utils");
 
-// Get the project directory from command-line arguments
-const appDirectory = process.argv[2];
-if (!appDirectory) {
-  console.error("Please provide the path to your React app directory.");
-  process.exit(1);
-}
-
-(async function addStripeIntegration() {
+async function addStripeIntegration(appDirectory) {
+  if (!appDirectory) {
+    console.error("Please provide the path to your React app directory.");
+    process.exit(1);
+  }
   console.log("\n--- Adding Stripe Integration ---");
 
   // Install Stripe packages
@@ -19,6 +16,7 @@ if (!appDirectory) {
   });
   
   // Create stripeProvider.jsx in src folder
+  const srcDir = path.join(appDirectory, "src");
   const providerPath = path.join(srcDir, "stripeProvider.jsx");
   const providerContent = `
 // src/StripeProvider.js
@@ -42,6 +40,12 @@ export default StripeProvider;
   fs.writeFileSync(providerPath, providerContent.trim());
   console.log(`Created: ${providerPath}`);
 
-
   console.log("Stripe has been added!");
-})();
+}
+
+module.exports = addStripeIntegration;
+
+if (require.main === module) {
+  const appDirectory = process.argv[2];
+  addStripeIntegration(appDirectory);
+}

--- a/setupReactAppScripts/scripts/features/tailwindprettier.js
+++ b/setupReactAppScripts/scripts/features/tailwindprettier.js
@@ -3,14 +3,11 @@ const fs = require("fs");
 const path = require("path");
 const { executeCommand } = require("../utils");
 
-// Get the project directory from command-line arguments
-const appDirectory = process.argv[2];
-if (!appDirectory) {
-  console.error("Please provide the path to your React app directory.");
-  process.exit(1);
-}
-
-(async function setupTailwindAndPrettier() {
+async function setupTailwindAndPrettier(appDirectory) {
+  if (!appDirectory) {
+    console.error("Please provide the path to your React app directory.");
+    process.exit(1);
+  }
   console.log("\n--- Adding Tailwind CSS and Prettier with Tailwind Plugin ---");
 
   // Install Tailwind CSS and PostCSS dependencies
@@ -53,4 +50,11 @@ module.exports = {
   console.log(`Created: ${prettierConfigPath}`);
 
   console.log("Tailwind CSS and Prettier with Tailwind plugin have been added!");
-})();
+}
+
+module.exports = setupTailwindAndPrettier;
+
+if (require.main === module) {
+  const appDirectory = process.argv[2];
+  setupTailwindAndPrettier(appDirectory);
+}

--- a/setupReactAppScripts/scripts/post-setup-react.js
+++ b/setupReactAppScripts/scripts/post-setup-react.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { executeCommand } = require('./utils');
-const { exec } = require('child_process');
+const addStripeIntegration = require('./features/stripe');
 
 // Get the project path from the command-line arguments
 const projectPath = process.argv[2];
@@ -62,29 +62,34 @@ if (fs.existsSync(templateIndexJsPath)) {
 
 // Step 3: Install npm packages in the project directory
 console.log("\n--- Installing packages in the project directory ---");
-executeCommand(`npm install react-firebase-hooks`, { cwd: projectPath });
-executeCommand(`npm install stripe`, { cwd: projectPath });
-executeCommand(`npm install dotenv`, { cwd: projectPath });
-executeCommand(`npm install cors`, { cwd: projectPath });
-executeCommand(`npm install liamc9npm@latest`, { cwd: projectPath });
-executeCommand(`npm install styled-components`, { cwd: projectPath });
-executeCommand(`npm install react-toastify`, { cwd: projectPath });
-executeCommand(`npm install swiper`, { cwd: projectPath});
-executeCommand(`npm install dragula`, { cwd: projectPath });
-executeCommand(`npm install react-router-dom`, { cwd: projectPath });
-executeCommand(`npm install react-icons`, { cwd: projectPath });
+const projectPackages = [
+  "react-firebase-hooks",
+  "stripe",
+  "dotenv",
+  "cors",
+  "liamc9npm@latest",
+  "styled-components",
+  "react-toastify",
+  "swiper",
+  "dragula",
+  "react-router-dom",
+  "react-icons",
+];
+projectPackages.forEach((pkg) => {
+  executeCommand(`npm install ${pkg}`, { cwd: projectPath });
+});
 
 
 // Step 4: Install npm packages in the functions directory
 console.log("\n--- Installing packages in the functions directory ---");
-executeCommand(`npm install stripe`, { cwd: functionsDir });
-executeCommand(`npm install dotenv`, { cwd: functionsDir });
-executeCommand(`npm install cors`, { cwd: functionsDir });
+const functionPackages = ["stripe", "dotenv", "cors"];
+functionPackages.forEach((pkg) => {
+  executeCommand(`npm install ${pkg}`, { cwd: functionsDir });
+});
 
-// Step 5: Run features/stripe.js after installations
-console.log("\n--- Running features/stripe.js ---");
-const stripeScriptPath = path.join(__dirname, "features", "stripe.js");
-executeCommand(`node "${stripeScriptPath}" "${projectPath}"`, { cwd: __dirname });
+// Step 5: Run Stripe setup
+console.log("\n--- Adding Stripe provider ---");
+addStripeIntegration(projectPath);
 
 // Final message
 console.log("\nSetup complete.");

--- a/setupReactAppScripts/scripts/setup-react-app.js
+++ b/setupReactAppScripts/scripts/setup-react-app.js
@@ -3,6 +3,9 @@
 const path = require("path");
 const fs = require("fs");
 const { askQuestion, executeCommand } = require("./utils");
+const addTailwindPrettier = require("./features/tailwindprettier");
+const addFirebase = require("./features/firebase");
+const addGitHub = require("./features/github");
 
 (async function main() {
   // Ensure a project name is provided.
@@ -61,15 +64,14 @@ const { askQuestion, executeCommand } = require("./utils");
   console.log("\nSimple React app setup complete!");
 
   // Execute feature scripts based on user selections.
-  const featureScriptsDir = path.join(__dirname, "features");
   if (addTailwindPrettier) {
-    executeCommand(`node tailwindprettier.js "${appDirectory}"`, { cwd: featureScriptsDir });
+    await addTailwindPrettier(appDirectory);
   }
   if (addFirebase) {
-    executeCommand(`node firebase.js "${appDirectory}"`, { cwd: featureScriptsDir });
+    await addFirebase(appDirectory);
   }
   if (addGitHub) {
-    executeCommand(`node github.js "${appDirectory}"`, { cwd: featureScriptsDir });
+    await addGitHub(appDirectory);
   }
 
   console.log("\nAll selected features have been added to your app!");


### PR DESCRIPTION
## Summary
- export feature scripts as functions so they can be reused
- call feature modules directly from `setup-react-app.js`
- simplify post setup installations using arrays
- fix stripe provider path and add module export
- document how to run the scripts

## Testing
- `node -c setupReactAppScripts/scripts/setup-react-app.js`
- `node -c setupReactAppScripts/scripts/post-setup-react.js`
- `node -c setupReactAppScripts/scripts/features/tailwindprettier.js`
- `node -c setupReactAppScripts/scripts/features/firebase.js`
- `node -c setupReactAppScripts/scripts/features/github.js`
- `node -c setupReactAppScripts/scripts/features/stripe.js`


------
https://chatgpt.com/codex/tasks/task_e_684ca27775e08330a7bc9767a71b184b